### PR TITLE
[fix] Route for ArbitraryNotionPage now has support for both uuid/non-uuid pageIds in slug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "next": "^14.1.4",
         "next-cloudinary": "^6.6.2",
         "notion-client": "^6.16.0",
+        "notion-utils": "^6.16.0",
         "react": "^18",
         "react-dom": "^18",
         "react-icons": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next": "^14.1.4",
     "next-cloudinary": "^6.6.2",
     "notion-client": "^6.16.0",
+    "notion-utils": "^6.16.0",
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.0.1",

--- a/src/app/(pages)/[slug]/page.tsx
+++ b/src/app/(pages)/[slug]/page.tsx
@@ -1,9 +1,12 @@
 import NotionPage from '@/components/NotionPage';
 import { getAllPageIds, getRecordMap, getTitleByPageId } from '@/lib/notion/utils';
+import { parsePageId } from 'notion-utils';
 
 export async function generateStaticParams() {
   const allPageIds = await getAllPageIds();
-  return allPageIds.map((pageId: string) => ({
+  const allPageIdsNoDashes = allPageIds.map(pageId => parsePageId(pageId, { uuid: false }));
+
+  return [...allPageIds, ...allPageIdsNoDashes].map((pageId: string) => ({
     slug: pageId,
   }));
 }


### PR DESCRIPTION
non-uuid
![image](https://github.com/user-attachments/assets/d611d3f8-1de7-4362-9862-c1e6277370e6)

uuid
![image](https://github.com/user-attachments/assets/647651be-fff3-45e7-92b7-d2cceb8fa856)