### PR TITLE
[fix] [feature] Event details on each event page

### DIFF
--- a/src/app/(pages)/events/[slug]/page.tsx
+++ b/src/app/(pages)/events/[slug]/page.tsx
@@ -1,5 +1,5 @@
-import NotionPage from '@/components/NotionPage';
-import { getEventPageIds } from '@/lib/notion/events';
+import { NotionPage, EventDetailsType } from '@/components/NotionPage';
+import { getEvent, getEventPageIds } from '@/lib/notion/events';
 import { getRecordMap, getTitleByPageId } from '@/lib/notion/utils';
 
 export async function generateStaticParams() {
@@ -13,9 +13,21 @@ type PropsType = {
 
 export default async function EventPage({ params }: PropsType) {
   const pageId = params.slug;
+  const event = await getEvent(pageId);
+  const eventDetails: EventDetailsType = {
+    date: event.date,
+    venue: event.venue,
+    status: event.status,
+  };
 
   const recordMap = await getRecordMap(pageId);
   const title = await getTitleByPageId(pageId);
 
-  return <NotionPage recordMap={recordMap} title={title} />;
+  return (
+    <NotionPage
+      recordMap={recordMap}
+      title={title}
+      eventDetails={eventDetails}
+    />
+  );
 }

--- a/src/app/(pages)/events/page.tsx
+++ b/src/app/(pages)/events/page.tsx
@@ -6,10 +6,16 @@ import BlockContainer from '@/components/BlockContainer';
 const EventsPage: React.FC = async () => {
   const res = await getEvents();
   return (
-    <div className='bg-blueprint-50 flex justify-center'>
-      <BlockContainer title='Blueprints Events' roundedCorners inner centered margin>
-        <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 px-4 sm:px-16 lg:px-12'>
-          {res.map(event => (
+    <div className="bg-blueprint-50 flex justify-center">
+      <BlockContainer
+        title="Blueprint Events"
+        roundedCorners
+        inner
+        centered
+        margin
+      >
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 px-4 sm:px-16 lg:px-12">
+          {res.map((event) => (
             <EventCard
               id={event.eventPageId}
               key={event.eventName}

--- a/src/components/NotionPage.tsx
+++ b/src/components/NotionPage.tsx
@@ -5,18 +5,61 @@ import Link from 'next/link';
 import { ExtendedRecordMap } from 'notion-types';
 import { NotionRenderer } from 'react-notion-x';
 import BlockContainer from './BlockContainer';
+import { BsCalendar3 } from 'react-icons/bs';
+import { MdOutlineLocationCity } from 'react-icons/md';
+import { MdOutlineUpcoming } from 'react-icons/md';
+
+export type EventDetailsType = {
+  date: string;
+  venue: string;
+  status: string;
+};
 
 type PropsType = {
   recordMap: ExtendedRecordMap;
   title: string;
+  eventDetails?: EventDetailsType;
 };
 
-export default function NotionPage({ recordMap, title }: PropsType) {
+export function NotionPage({ recordMap, title, eventDetails }: PropsType) {
   return (
-    <div className='flex flex-col items-center justify-center py-12 bg-blue-50'>
-      <h1 className='text-5xl text-blueprint font-bold mb-10'>{title}</h1>
+    <div className="flex flex-col items-center justify-center py-12 bg-blue-50">
+      <h1 className="text-5xl text-blueprint font-bold mb-10 text-center">
+        {title}
+      </h1>
 
       <BlockContainer roundedCorners centered>
+        <div className="px-[96px] w-full">
+          {eventDetails && (
+            <div className="mb-10">
+              <h1 className="text-3xl text-gray-800 font-semibold mb-5">
+                Event Details
+              </h1>
+              <div className="grid grid-cols-2 gap-2 w-[500px] items-center">
+                <p className="flex gap-1 items-center text-md text-gray-800">
+                  <BsCalendar3 /> Date
+                </p>
+                <p className="text-md text-gray-800">{eventDetails.date}</p>
+                <p className="flex gap-1 items-center text-md text-gray-800">
+                  <MdOutlineLocationCity /> Venue
+                </p>
+                <p className="text-md text-gray-800">{eventDetails.venue}</p>
+                <p className="flex gap-1 items-center text-md text-gray-800">
+                  <MdOutlineUpcoming /> Status
+                </p>
+                {eventDetails.status === 'Scheduled' ? (
+                  <span className="px-3 py-1 text-white bg-green-500 rounded-full text-xs font-bold w-fit">
+                    Upcoming
+                  </span>
+                ) : (
+                  <span className="px-3 py-1 text-white bg-gray-400 rounded-full text-xs font-bold w-fit">
+                    Passed
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
         <NotionRenderer
           recordMap={recordMap}
           // fullPage={true}

--- a/src/lib/notion/events.ts
+++ b/src/lib/notion/events.ts
@@ -58,10 +58,15 @@ export async function getEvents() {
       continue;
     }
     const eventName = page.properties.Name.title[0].text.content;
-    const date = format(
-      parseISO(page.properties.Date.date.start),
-      'MMMM dd, yyyy h:mm a'
-    );
+    let date = '';
+    if (page.properties.Date.date.start.includes('T')) {
+      date = format(
+        parseISO(page.properties.Date.date.start),
+        'MMMM dd, yyyy h:mm a'
+      );
+    } else {
+      date = format(parseISO(page.properties.Date.date.start), 'MMMM dd, yyyy');
+    }
     console.log(date);
     const venue = page.properties.Venue.rich_text[0].plain_text;
     const status = page.properties.Status.status.name;

--- a/src/lib/notion/events.ts
+++ b/src/lib/notion/events.ts
@@ -15,6 +15,30 @@ export type EventDataType = {
 
 export const EVENTS_DATABASE_ID = 'f988151abd6448ebb70053c5ca1278f9';
 
+export async function getEvent(id: string) {
+  const page = (await notion.pages.retrieve({ page_id: id })) as any;
+  let date = '';
+  if (page.properties.Date.date.start.includes('T')) {
+    date = format(
+      parseISO(page.properties.Date.date.start),
+      'MMMM dd, yyyy h:mm a'
+    );
+  } else {
+    date = format(parseISO(page.properties.Date.date.start), 'MMMM dd, yyyy');
+  }
+  const event: EventDataType = {
+    eventPageId: id,
+    eventName: page.properties.Name.title[0].text.content,
+    date: date,
+    venue: page.properties.Venue.rich_text[0].plain_text,
+    status: page.properties.Status.status.name,
+    description: page.properties.Description.rich_text[0]?.plain_text || '',
+    coverURL:
+      page.properties['Cover URL'].rich_text[0]?.plain_text || '/default',
+  };
+  return event;
+}
+
 export async function getEventPageIds() {
   return await getPageIds(EVENTS_DATABASE_ID);
 }
@@ -67,7 +91,6 @@ export async function getEvents() {
     } else {
       date = format(parseISO(page.properties.Date.date.start), 'MMMM dd, yyyy');
     }
-    console.log(date);
     const venue = page.properties.Venue.rich_text[0].plain_text;
     const status = page.properties.Status.status.name;
     const description =


### PR DESCRIPTION
Made some small fixes:
- changed "Blueprints Events" to "Blueprint Events" on the events page
- Event time defaulted to 12:00 AM if not included so I fixed it by not showing the time if not included

Feature:
- Event details at the beginning of each event slug page