### PR TITLE
Fixing minor issues in students page

### DIFF
--- a/src/app/(pages)/students/_components/TeamProfile.tsx
+++ b/src/app/(pages)/students/_components/TeamProfile.tsx
@@ -6,12 +6,11 @@ import { CldImage } from 'next-cloudinary';
 function TeamProfileBase({ student, hover = false }: { student: StudentDataType; hover: boolean }) {
   return (
     <div
-      className={`flex flex-col items-center text-center space-y-1 py-3 rounded-2xl ${
-        hover && 'transition ease-in-out hover:scale-110 hover:bg-blueprint-50 duration-200'
-      }`}
+      className={`flex flex-col items-center text-center space-y-1 py-3 rounded-2xl ${hover && 'transition ease-in-out hover:scale-110 hover:bg-blueprint-50 duration-200'
+        }`}
     >
-      <div className='rounded-full overflow-hidden w-32 h-32 mb-2 border-white border-2'>
-        <CldImage src={student.imageUrl} width={128} height={128} alt={'Picture of ' + student.name} />
+      <div className='rounded-full flex items-center overflow-hidden w-32 h-32 mb-2 border-white border-2'>
+        <CldImage src={student.imageUrl} width={128} height={128} alt={'Picture of ' + (hover ? student.name : "blueprint logo")} />
       </div>
       <p className='text-black text-lg font-bold'>{student.name}</p>
       <p className='text-black capitalize'>{student.role}</p>


### PR DESCRIPTION
Old alt text was inaccurate for TeamProfiles that did not have images of the students. It used to say "image of <studentName>", now it says "image of blueprint logo"

TeamProfile images were not centered. Now they are.