### PR TITLE
Fix empty div render in NotionPage

### DIFF
--- a/src/components/NotionPage.tsx
+++ b/src/components/NotionPage.tsx
@@ -27,8 +27,8 @@ export default function NotionPage({ recordMap, title, eventDetails }: PropsType
       <h1 className="text-5xl text-blueprint font-bold mb-10 text-center">{title}</h1>
 
       <BlockContainer roundedCorners centered>
-        <div className="px-[96px] w-full">
-          {eventDetails && (
+        {eventDetails && (
+          <div className="px-[96px] w-full">
             <div className="mb-10">
               <h1 className="text-3xl text-gray-800 font-semibold mb-5">Event Details</h1>
               <div className="grid grid-cols-2 gap-2 w-[500px] items-center">
@@ -52,8 +52,8 @@ export default function NotionPage({ recordMap, title, eventDetails }: PropsType
                 )}
               </div>
             </div>
-          )}
-        </div>
+          </div>
+        )}
         <NotionRenderer
           recordMap={recordMap}
           // fullPage={true}


### PR DESCRIPTION
# Description of Changes

 NotionPage.tsx conditionally renders event details. The line responsible for this was one div layer too low, causing an empty div to be rendered and adding extra spacing to the page. I lifted it up to where it should have been initially placed. 

# Pictures

Before (1296px height in this example):

![image](https://github.com/user-attachments/assets/64704a9e-71ec-4b52-885c-acbf91332837)

After (1248px height in this example, successful reduction!):

![image](https://github.com/user-attachments/assets/fc08dbaa-53e5-4013-9149-a5b363038b66)


## Related Issues

- Closes #121 

## Checklist

- [x] MR title is meaningful and accurate
- [x] This MR has an associated GitHub Issues ticket
- [ ] GitHub Issues ticket fix version for this issue is correct
- [ ] ~[Changelog entry](https://keepachangelog.com/en/1.0.0/) has been made~
- [x] I promise that my commit message for this MR will be clear, meaningful,
      and useful to others. I will ensure this by editing the final commit message
      in GitHub prior to merging
