### PR TITLE
Replace Notion IDs with custom slugs

### DIFF
--- a/src/app/(pages)/events/[slug]/page.tsx
+++ b/src/app/(pages)/events/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import NotionPage, { EventDetailsType } from '@/components/NotionPage';
-import { getEvent, getEvents } from '@/lib/notion/events';
+import { getEventPageBySlug, getEvents } from '@/lib/notion/events';
 import { getRecordMap, getTitleByPageId } from '@/lib/notion/utils';
 import { notFound } from 'next/navigation';
 
@@ -15,7 +15,7 @@ type PropsType = {
 };
 
 export default async function EventPage({ params }: PropsType) {
-  const event = await getEvent(params.slug);
+  const event = await getEventPageBySlug(params.slug);
 
   if (!event) notFound();
 

--- a/src/app/(pages)/events/[slug]/page.tsx
+++ b/src/app/(pages)/events/[slug]/page.tsx
@@ -1,10 +1,12 @@
 import NotionPage, { EventDetailsType } from '@/components/NotionPage';
-import { getEvent, getEventPageIds } from '@/lib/notion/events';
+import { getEvent, getEvents } from '@/lib/notion/events';
 import { getRecordMap, getTitleByPageId } from '@/lib/notion/utils';
 
 export async function generateStaticParams() {
-  const pageIds = await getEventPageIds();
-  return pageIds.map((slug: string) => ({ slug }));
+  const events = await getEvents();
+  return events.map(event => ({
+    slug: event.slug,
+  }));
 }
 
 type PropsType = {
@@ -12,16 +14,15 @@ type PropsType = {
 };
 
 export default async function EventPage({ params }: PropsType) {
-  const pageId = params.slug;
-  const event = await getEvent(pageId);
+  const event = await getEvent(params.slug);
   const eventDetails: EventDetailsType = {
     date: event.date,
     venue: event.venue,
     status: event.status,
   };
 
-  const recordMap = await getRecordMap(pageId);
-  const title = await getTitleByPageId(pageId);
+  const recordMap = await getRecordMap(event.eventPageId);
+  const title = await getTitleByPageId(event.eventPageId);
 
   return <NotionPage recordMap={recordMap} title={title} eventDetails={eventDetails} />;
 }

--- a/src/app/(pages)/events/[slug]/page.tsx
+++ b/src/app/(pages)/events/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import NotionPage, { EventDetailsType } from '@/components/NotionPage';
 import { getEvent, getEvents } from '@/lib/notion/events';
 import { getRecordMap, getTitleByPageId } from '@/lib/notion/utils';
+import { notFound } from 'next/navigation';
 
 export async function generateStaticParams() {
   const events = await getEvents();
@@ -15,6 +16,9 @@ type PropsType = {
 
 export default async function EventPage({ params }: PropsType) {
   const event = await getEvent(params.slug);
+
+  if (!event) notFound();
+
   const eventDetails: EventDetailsType = {
     date: event.date,
     venue: event.venue,

--- a/src/app/(pages)/events/_components/EventCard.tsx
+++ b/src/app/(pages)/events/_components/EventCard.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { CldImage } from 'next-cloudinary';
 
 interface EventCardProps {
-  id: string;
+  slug: string;
   imgURL: string;
   title: string;
   venue: string;
@@ -13,10 +13,10 @@ interface EventCardProps {
   isUpcoming: boolean;
 }
 
-const EventCard: React.FC<EventCardProps> = ({ id, imgURL, title, venue, time, description, isUpcoming }) => {
+const EventCard: React.FC<EventCardProps> = ({ slug, imgURL, title, venue, time, description, isUpcoming }) => {
   return (
     <Link
-      href={`/events/${id}`}
+      href={`/events/${slug}`}
       target="_blank"
       rel="noopener noreferrer"
       className="flex flex-col bg-white rounded-[30px] overflow-hidden shadow-md transition-transform duration-200 mt-12 max-w-md w-full relative hover:shadow-xl transform hover:-translate-y-1 cursor-pointer"

--- a/src/app/(pages)/events/page.tsx
+++ b/src/app/(pages)/events/page.tsx
@@ -11,7 +11,7 @@ const EventsPage: React.FC = async () => {
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 px-4 sm:px-16 lg:px-12">
           {res.map(event => (
             <EventCard
-              id={event.eventPageId}
+              slug={event.slug}
               key={event.eventName}
               imgURL={event.coverURL}
               title={event.eventName}

--- a/src/app/(pages)/home/_components/EventCard.tsx
+++ b/src/app/(pages)/home/_components/EventCard.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 export default function EventCard({ data }: { data: EventDataType }) {
   return (
     <div className="group">
-      <Link href={'/events/' + data.eventPageId} className="relative p-1">
+      <Link href={'/events/' + data.slug} className="relative p-1">
         <Card className="h-[23rem] md:h-[36rem] min-w-fit relative rounded-[50px] shadow-[0px_4px_4px_0_rgba(0,0,0,0.3)] overflow-hidden">
           <CldImage
             src={data.homePageURL || '/default'}

--- a/src/app/(pages)/home/_components/ProjectCard.tsx
+++ b/src/app/(pages)/home/_components/ProjectCard.tsx
@@ -22,7 +22,7 @@ export default function HomeProjectCard({ data }: { data: ProjectDataType }) {
             {data.productName}
           </p>
         </span>
-        <Link href={'/projects/' + data.pageId} className="absolute w-full h-full" />
+        <Link href={'/projects/' + data.slug} className="absolute w-full h-full" />
         <Link href={data.externalUrl || ''} className="absolute top-2 right-2">
           <div>
             <IoLogoGithub className="rounded-full bg-blueprint-50 opacity-0 group-hover:opacity-100 w-20 h-20 transition-color duration-300 ease-in-out hover:text-blueprint-300 text-blueprint" />

--- a/src/app/(pages)/projects/[slug]/page.tsx
+++ b/src/app/(pages)/projects/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { getProject, getProjects } from '@/lib/notion/projects';
 import { getRecordMap, getTitleByPageId } from '@/lib/notion/utils';
 import NotionPage from '@/components/NotionPage';
+import { notFound } from 'next/navigation';
 
 export async function generateStaticParams() {
   const projects = await getProjects();
@@ -15,6 +16,8 @@ type PropsType = {
 
 export default async function ProjectPage({ params }: PropsType) {
   const project = await getProject(params.slug);
+
+  if (!project) notFound();
 
   const title = await getTitleByPageId(project.pageId);
   const recordMap = await getRecordMap(project.pageId);

--- a/src/app/(pages)/projects/[slug]/page.tsx
+++ b/src/app/(pages)/projects/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { getProject, getProjects } from '@/lib/notion/projects';
+import { getProjectPageBySlug, getProjects } from '@/lib/notion/projects';
 import { getRecordMap, getTitleByPageId } from '@/lib/notion/utils';
 import NotionPage from '@/components/NotionPage';
 import { notFound } from 'next/navigation';
@@ -15,12 +15,12 @@ type PropsType = {
 };
 
 export default async function ProjectPage({ params }: PropsType) {
-  const project = await getProject(params.slug);
+  const project = await getProjectPageBySlug(params.slug);
 
   if (!project) notFound();
 
-  const title = await getTitleByPageId(project.pageId);
-  const recordMap = await getRecordMap(project.pageId);
+  const title = await getTitleByPageId(project.id);
+  const recordMap = await getRecordMap(project.id);
 
   return <NotionPage recordMap={recordMap} title={title} />;
 }

--- a/src/app/(pages)/projects/[slug]/page.tsx
+++ b/src/app/(pages)/projects/[slug]/page.tsx
@@ -1,10 +1,12 @@
-import { getProjectPageIds } from '@/lib/notion/projects';
+import { getProject, getProjects } from '@/lib/notion/projects';
 import { getRecordMap, getTitleByPageId } from '@/lib/notion/utils';
 import NotionPage from '@/components/NotionPage';
 
 export async function generateStaticParams() {
-  const pageIds = await getProjectPageIds();
-  return pageIds.map((slug: string) => ({ slug }));
+  const projects = await getProjects();
+  return projects.map(project => ({
+    slug: project.slug,
+  }));
 }
 
 type PropsType = {
@@ -12,10 +14,10 @@ type PropsType = {
 };
 
 export default async function ProjectPage({ params }: PropsType) {
-  const pageId = params.slug;
+  const project = await getProject(params.slug);
 
-  const title = await getTitleByPageId(pageId);
-  const recordMap = await getRecordMap(pageId);
+  const title = await getTitleByPageId(project.pageId);
+  const recordMap = await getRecordMap(project.pageId);
 
   return <NotionPage recordMap={recordMap} title={title} />;
 }

--- a/src/app/(pages)/projects/_components/PastProjectCard.tsx
+++ b/src/app/(pages)/projects/_components/PastProjectCard.tsx
@@ -6,7 +6,7 @@ import { CardContent, CardTitle } from '@/components/ui/card';
 
 export default function PastProjectCard({ data }: { data: ProjectDataType }) {
   return (
-    <a href={'/projects/' + data.pageId}>
+    <a href={'/projects/' + data.slug}>
       <div className="bg-gradient-to-t from-[#0170DC] to-[#6191BC] rounded-[40px] flex flex-col max-h-[500px] p-4 outline hover:outline-white hover:outline-4 transition-all ease-in-out duration-150">
         {data.logoUrl && (
           <div className="flex justify-center items-center mb-4">

--- a/src/app/(pages)/projects/_components/ProjectCard.tsx
+++ b/src/app/(pages)/projects/_components/ProjectCard.tsx
@@ -35,7 +35,7 @@ export default function ProjectCard({ data }: { data: ProjectDataType }) {
             </LinkButton>
           )}
           {data.pageId && (
-            <LinkButton href={'/projects/' + data.pageId} newTab={true} variant="icon">
+            <LinkButton href={'/projects/' + data.slug} newTab={true} variant="icon">
               <FaArrowCircleRight className="text-5xl" />
             </LinkButton>
           )}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-[calc(100vh-300px)] bg-blueprint-50 flex items-center justify-center px-4">
+      <div className="max-w-lg w-full bg-white rounded-2xl p-8 text-center shadow-lg">
+        <h1 className="text-4xl font-bold text-blueprint mb-4">404 - Page Not Found</h1>
+        <p className="text-gray-600 mb-8">
+          The page you&apos;re looking for doesn&apos;t exist. Please check the URL and try again.
+        </p>
+        <div className="space-x-4">
+          <Link
+            href="/"
+            className="inline-block bg-gray-200 text-gray-800 px-6 py-2 rounded-full hover:bg-gray-300 transition-colors"
+          >
+            Go home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/notion/events.ts
+++ b/src/lib/notion/events.ts
@@ -19,7 +19,7 @@ export const EVENTS_DATABASE_ID = 'f988151abd6448ebb70053c5ca1278f9';
 export async function getEvent(slug: string) {
   const events = await getEvents();
   const event = events.find(e => e.slug === slug);
-  if (!event) throw new Error(`Event with slug ${slug} not found`);
+  if (!event) return undefined;
   return event;
 }
 

--- a/src/lib/notion/projects.ts
+++ b/src/lib/notion/projects.ts
@@ -1,5 +1,5 @@
 import notion from '.';
-import { getPageIds } from './utils';
+import { getPageBySlug, getPageIds } from './utils';
 
 export type ProjectDataType = {
   pageId: string;
@@ -70,9 +70,6 @@ export async function getProjects(options?: { featuredOnly: boolean }) {
   return projects;
 }
 
-export async function getProject(slug: string) {
-  const projects = await getProjects();
-  const project = projects.find(p => p.slug === slug);
-  if (!project) return undefined;
-  return project;
+export async function getProjectPageBySlug(slug: string) {
+  return getPageBySlug(PROJECTS_DATABASE_ID, slug);
 }

--- a/src/lib/notion/projects.ts
+++ b/src/lib/notion/projects.ts
@@ -3,6 +3,7 @@ import { getPageIds } from './utils';
 
 export type ProjectDataType = {
   pageId: string;
+  slug: string;
   companyName: string;
   productName: string | undefined | null;
   description: string | undefined | null;
@@ -24,39 +25,23 @@ export async function getProjectPageIds() {
 }
 
 export async function getFeaturedProjects() {
-  const projectPageIds = await getProjectPageIds();
-  const projects: ProjectDataType[] = [];
-
-  for (const pageId of projectPageIds) {
-    const page = (await notion.pages.retrieve({ page_id: pageId })) as any;
-    if (page.properties.Featured.checkbox) {
-      const companyName = page.properties.Name.title[0].plain_text;
-      const productName = page.properties['Product Name'].rich_text[0]?.plain_text || '';
-      const logoUrl = page.properties['Logo URL'].rich_text[0]?.plain_text || '/default';
-      const externalUrl = page.properties.URL.url;
-      const gitHubUrl = page.properties.gitHubUrl;
-      projects.push({
-        pageId,
-        companyName,
-        productName,
-        description: '',
-        year: '',
-        logoUrl,
-        externalUrl,
-        status: 'Done',
-        gitHubUrl,
-      });
-    }
-  }
-  return projects;
+  return await getProjects({ featuredOnly: true });
 }
 
-export async function getProjects() {
+export async function getProjects(options?: { featuredOnly: boolean }) {
+  const featuredOnly = options?.featuredOnly ?? false;
+
   const projectPageIds = await getProjectPageIds();
   const projects: ProjectDataType[] = [];
 
   for (const pageId of projectPageIds) {
     const page = (await notion.pages.retrieve({ page_id: pageId })) as any;
+
+    const isFeatured = page.properties.Featured.checkbox;
+
+    if (featuredOnly && !isFeatured) {
+      continue;
+    }
 
     const companyName = page.properties.Name.title[0].plain_text;
     const productName = page.properties['Product Name'].rich_text[0]?.plain_text;
@@ -66,6 +51,7 @@ export async function getProjects() {
     const externalUrl = page.properties.URL.url;
     const status = page.properties.Status.select.name;
     const gitHubUrl = page.properties.gitHubUrl.url;
+    const slug = page.properties.Slug.rich_text[0]?.plain_text || pageId;
 
     projects.push({
       pageId,
@@ -77,8 +63,16 @@ export async function getProjects() {
       externalUrl,
       status,
       gitHubUrl,
+      slug,
     });
   }
 
   return projects;
+}
+
+export async function getProject(slug: string) {
+  const projects = await getProjects();
+  const project = projects.find(p => p.slug === slug);
+  if (!project) throw new Error(`Project with slug ${slug} not found`);
+  return project;
 }

--- a/src/lib/notion/projects.ts
+++ b/src/lib/notion/projects.ts
@@ -73,6 +73,6 @@ export async function getProjects(options?: { featuredOnly: boolean }) {
 export async function getProject(slug: string) {
   const projects = await getProjects();
   const project = projects.find(p => p.slug === slug);
-  if (!project) throw new Error(`Project with slug ${slug} not found`);
+  if (!project) return undefined;
   return project;
 }

--- a/src/lib/notion/utils.ts
+++ b/src/lib/notion/utils.ts
@@ -39,3 +39,19 @@ export async function getTitleByPageId(page_id: string) {
   const typedRes = res as any;
   return typedRes.properties.Name.title[0].plain_text;
 }
+
+export async function getPageBySlug(database_id: string, slug: string) {
+  const res = await notion.databases.query({
+    database_id,
+    filter: {
+      property: 'Slug',
+      rich_text: {
+        equals: slug,
+      },
+    },
+  });
+
+  if (!res.results.length) return undefined;
+
+  return res.results[0];
+}


### PR DESCRIPTION
# Description of Changes

- Added custom URL slugs for both projects and events pages, replacing Notion page IDs in URLs
- Added "Slug" property to both Projects and Events Notion databases
- Updated data types and fetch functions to include slug field
- Modified all project and event card links to use slugs
- Maintained backwards compatibility by falling back to page IDs when slugs aren't set

## Related Issues

- Closes #91 

## Checklist

- [x] MR title is meaningful and accurate
- [x] This MR has an associated GitHub Issues ticket
- [x] GitHub Issues ticket fix version for this issue is correct
- [x] I promise that my commit message for this MR will be clear, meaningful,
      and useful to others. I will ensure this by editing the final commit message
      in GitHub prior to merging