### PR TITLE
fix: add missing  home event cover image url

### DIFF
--- a/src/lib/notion/events.ts
+++ b/src/lib/notion/events.ts
@@ -68,6 +68,7 @@ function getEventPageProperties(page: any, pageId: string) {
     status: page.properties.Status.status.name,
     description: page.properties.Description.rich_text[0]?.plain_text || '',
     coverURL: page.properties['Cover URL'].rich_text[0]?.plain_text || '/default',
+    homePageURL: page.properties['Home Cover URL'].rich_text[0]?.plain_text || '/default',
     slug: page.properties.Slug.rich_text[0]?.plain_text || pageId,
   };
 }


### PR DESCRIPTION
# Description of Changes

In commit [3d9...21f](https://github.com/Carleton-Blueprint/carleton-blueprint.github.io/commit/3d9db63ff015ee76dfbea7b811c1767dab26621f) I removed retrieval of the "Home Cover URL" property on Event notion pages which was a big mistake!

I've reverted this and made our home page pretty again

## Related Issues

- Closes #150 
