### PR TITLE
Update NotionPage mobile responsiveness 

### DIFF
--- a/src/components/NotionPage.tsx
+++ b/src/components/NotionPage.tsx
@@ -26,44 +26,46 @@ export default function NotionPage({ recordMap, title, eventDetails }: PropsType
     <div className="flex flex-col items-center justify-center py-12 bg-blue-50">
       <h1 className="text-5xl text-blueprint font-bold mb-10 text-center">{title}</h1>
 
-      <BlockContainer roundedCorners centered>
-        {eventDetails && (
-          <div className="px-[96px] w-full">
-            <div className="mb-10">
-              <h1 className="text-3xl text-gray-800 font-semibold mb-5">Event Details</h1>
-              <div className="grid grid-cols-2 gap-2 w-[500px] items-center">
-                <p className="flex gap-1 items-center text-md text-gray-800">
-                  <BsCalendar3 /> Date
-                </p>
-                <p className="text-md text-gray-800">{eventDetails.date}</p>
-                <p className="flex gap-1 items-center text-md text-gray-800">
-                  <MdOutlineLocationCity /> Venue
-                </p>
-                <p className="text-md text-gray-800">{eventDetails.venue}</p>
-                <p className="flex gap-1 items-center text-md text-gray-800">
-                  <MdOutlineUpcoming /> Status
-                </p>
-                {eventDetails.status === 'Scheduled' ? (
-                  <span className="px-3 py-1 text-white bg-green-500 rounded-full text-xs font-bold w-fit">
-                    Upcoming
-                  </span>
-                ) : (
-                  <span className="px-3 py-1 text-white bg-gray-400 rounded-full text-xs font-bold w-fit">Passed</span>
-                )}
+      <div className="md:w-auto w-full">
+        <BlockContainer roundedCorners centered>
+          {eventDetails && (
+            <div className="md:px-[96px] w-full">
+              <div className="mb-10">
+                <h1 className="text-3xl text-gray-800 font-semibold mb-5">Event Details</h1>
+                <div className="grid grid-cols-2 gap-2 md:w-[500px] items-center">
+                  <p className="flex gap-1 items-center text-md text-gray-800">
+                    <BsCalendar3 /> Date
+                  </p>
+                  <p className="text-md text-gray-800">{eventDetails.date}</p>
+                  <p className="flex gap-1 items-center text-md text-gray-800">
+                    <MdOutlineLocationCity /> Venue
+                  </p>
+                  <p className="text-md text-gray-800">{eventDetails.venue}</p>
+                  <p className="flex gap-1 items-center text-md text-gray-800">
+                    <MdOutlineUpcoming /> Status
+                  </p>
+                  {eventDetails.status === 'Scheduled' ? (
+                    <span className="px-3 py-1 text-white bg-green-500 rounded-full text-xs font-bold w-fit">
+                      Upcoming
+                    </span>
+                  ) : (
+                    <span className="px-3 py-1 text-white bg-gray-400 rounded-full text-xs font-bold w-fit">Passed</span>
+                  )}
+                </div>
               </div>
             </div>
-          </div>
-        )}
-        <NotionRenderer
-          recordMap={recordMap}
-          // fullPage={true}
-          // darkMode={false}
-          components={{
-            nextImage: Image,
-            nextLink: Link,
-          }}
-        />
-      </BlockContainer>
+          )}
+          <NotionRenderer
+            recordMap={recordMap}
+            // fullPage={true}
+            // darkMode={false}
+            components={{
+              nextImage: Image,
+              nextLink: Link,
+            }}
+          />
+        </BlockContainer>
+      </div>
     </div>
   );
 }

--- a/src/components/NotionPage.tsx
+++ b/src/components/NotionPage.tsx
@@ -49,7 +49,9 @@ export default function NotionPage({ recordMap, title, eventDetails }: PropsType
                       Upcoming
                     </span>
                   ) : (
-                    <span className="px-3 py-1 text-white bg-gray-400 rounded-full text-xs font-bold w-fit">Passed</span>
+                    <span className="px-3 py-1 text-white bg-gray-400 rounded-full text-xs font-bold w-fit">
+                      Passed
+                    </span>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
# Description of Changes

- Added outer div with responsive width controls (`md:w-auto w-full`) to prevent container overflow
This fixes:
![image](https://github.com/user-attachments/assets/c4bf51db-91fe-49ac-a948-8377bb145a47) 
![image](https://github.com/user-attachments/assets/82ca5855-8ca8-47cf-af94-681cd8d2e524)


- Added `md:` breakpoint to the hardcoded padding (`px-[96px]`) and width (`w-500px`) on event details divs to keep text centered on mobile
This fixes:
![image](https://github.com/user-attachments/assets/28ba7fa7-b7dc-4d2c-8c92-4cff28aef78f)

Result:
![image](https://github.com/user-attachments/assets/e28dd217-7b6d-4505-b290-067850574c25)

## Related Issues

- Closes #152 

## Checklist

- [x] MR title is meaningful and accurate
- [x] This MR has an associated GitHub Issues ticket
- [x] Code quality check has been run `npm run quality`
- [x] Preview deployment has passed and looks as expected
- [x] I promise that my commit message for this MR will be clear, meaningful,
      and useful to others. I will ensure this by editing the final commit message
      in GitHub prior to merging

If a checklist item is completed for this MR, place an `x` inside of the square
brackets for that item. If a checklist item is not applicable for this MR, please
note that by wrapping that line with `~` characters, ~like this~.

> Make sure you squash your commits before merging!
