### PR TITLE
[feat] Ignore ".netlify" during code quality checks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+.netlify

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 src/components/ui
+.netlify


### PR DESCRIPTION
When Netlify builds the project, it injects a ".netlify" folder into the directory for some reason. There is dirty code in there beyond our control which fails our prettier/eslint checks.

## Checklist

- [x] MR title is meaningful and accurate
- [ ] This MR has an associated GitHub Issues ticket
- [x] Code quality check has been run `npm run quality`
- [x] Preview deployment has passed and looks as expected
- [x] I promise that my commit message for this MR will be clear, meaningful,
      and useful to others. I will ensure this by editing the final commit message
      in GitHub prior to merging

If a checklist item is completed for this MR, place an `x` inside of the square
brackets for that item. If a checklist item is not applicable for this MR, please
note that by wrapping that line with `~` characters, ~like this~.

> Make sure you squash your commits before merging!
