### PR TITLE
specified end of line character in prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -8,5 +8,6 @@
   "arrowParens": "avoid",
   "jsxSingleQuote": false,
   "bracketSpacing": true,
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "endOfLine": "lf"
 }


### PR DESCRIPTION
# Description of Changes

specified end of line character for prettierrc

## Related Issues

- Closes #202 

## Checklist

- [x] MR title is meaningful and accurate
- [x] This MR has an associated GitHub Issues ticket
- [x] Code quality check has been run `npm run quality`
- [x] Preview deployment has passed and looks as expected
- [x] I promise that my commit message for this MR will be clear, meaningful,
      and useful to others. I will ensure this by editing the final commit message
      in GitHub prior to merging

If a checklist item is completed for this MR, place an `x` inside of the square
brackets for that item. If a checklist item is not applicable for this MR, please
note that by wrapping that line with `~` characters, ~like this~.

> Make sure you squash your commits before merging!
