### PR TITLE
Error handling and type checking in notion library

### DIFF
--- a/src/app/(pages)/events/[slug]/page.tsx
+++ b/src/app/(pages)/events/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import NotionPage, { EventDetailsType } from '@/components/NotionPage';
 import { getEventPageBySlug, getEvents } from '@/lib/notion/events';
-import { getRecordMap, getTitleByPageId } from '@/lib/notion/utils';
+import { getRecordMap } from '@/lib/notion/utils';
 import { notFound } from 'next/navigation';
 
 export async function generateStaticParams() {
@@ -26,7 +26,7 @@ export default async function EventPage({ params }: PropsType) {
   };
 
   const recordMap = await getRecordMap(event.eventPageId);
-  const title = await getTitleByPageId(event.eventPageId);
+  const title = event.eventName;
 
   return <NotionPage recordMap={recordMap} title={title} eventDetails={eventDetails} />;
 }

--- a/src/app/(pages)/events/_components/EventCard.tsx
+++ b/src/app/(pages)/events/_components/EventCard.tsx
@@ -21,7 +21,7 @@ const EventCard: React.FC<EventCardProps> = ({ slug, imgURL, title, venue, time,
       rel="noopener noreferrer"
       className="relative mt-12 flex w-full max-w-md transform cursor-pointer flex-col overflow-hidden rounded-[30px] bg-white shadow-md transition-transform duration-200 hover:-translate-y-1 hover:shadow-xl"
     >
-      <div className="relative h-72 w-full">
+      <div className="relative w-full overflow-hidden md:h-64">
         <div className="max-h-full overflow-hidden">
           <CldImage src={imgURL} alt={title} width={400} height={400} className="rounded-lg" />
         </div>

--- a/src/app/(pages)/projects/[slug]/page.tsx
+++ b/src/app/(pages)/projects/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { getProjectPageBySlug, getProjects } from '@/lib/notion/projects';
-import { getRecordMap, getTitleByPageId } from '@/lib/notion/utils';
+import { getRecordMap } from '@/lib/notion/utils';
 import NotionPage from '@/components/NotionPage';
 import { notFound } from 'next/navigation';
 
@@ -19,8 +19,8 @@ export default async function ProjectPage({ params }: PropsType) {
 
   if (!project) notFound();
 
-  const title = await getTitleByPageId(project.id);
-  const recordMap = await getRecordMap(project.id);
+  const title = project.companyName;
+  const recordMap = await getRecordMap(project.projectPageId);
 
   return <NotionPage recordMap={recordMap} title={title} />;
 }

--- a/src/lib/notion/events.ts
+++ b/src/lib/notion/events.ts
@@ -1,6 +1,8 @@
 import notion from '.';
 import { parseISO, format } from 'date-fns';
 import { getPageBySlug, getPageIds } from './utils';
+import { isFullPage } from '@notionhq/client';
+import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 
 export type EventDataType = {
   eventPageId: string;
@@ -31,13 +33,20 @@ export async function getEvents(options?: { featuredOnly: boolean }) {
   const events: EventDataType[] = [];
 
   for (const eventPageId of eventPageIds) {
-    const page = (await notion.pages.retrieve({ page_id: eventPageId })) as any;
+    const page = await notion.pages.retrieve({ page_id: eventPageId });
+
+    if (!isFullPage(page)) continue;
+    if (page.properties.Featured.type !== 'checkbox') continue;
+    if (page.properties.Visibility.type !== 'checkbox') continue;
 
     if ((featuredOnly && !page.properties.Featured.checkbox) || !page.properties.Visibility.checkbox) {
       continue;
     }
 
-    events.push({ eventPageId, ...getEventPageProperties(page, eventPageId) });
+    const properties = getEventPageProperties(page, eventPageId);
+    if (!properties) continue;
+
+    events.push({ eventPageId, ...properties });
   }
 
   return events;
@@ -45,28 +54,43 @@ export async function getEvents(options?: { featuredOnly: boolean }) {
 
 export async function getEventPageBySlug(slug: string) {
   const eventPage = await getPageBySlug(EVENTS_DATABASE_ID, slug);
-
   if (!eventPage) return undefined;
+  if (!isFullPage(eventPage)) return undefined;
 
   const eventPageId = eventPage.id;
+  const properties = getEventPageProperties(eventPage, eventPageId);
+  if (!properties) return undefined;
 
-  return { eventPageId, ...getEventPageProperties(eventPage, eventPageId) };
+  return { eventPageId, ...properties };
 }
 
-function getEventPageProperties(page: any, pageId: string) {
+function getEventPageProperties(page: PageObjectResponse, pageId: string) {
+  if (page.properties.Date.type !== 'date') return false;
+  if (page.properties.Name.type !== 'title') return false;
+  if (page.properties.Venue.type !== 'rich_text') return false;
+  if (page.properties.Status.type !== 'status' || !page.properties.Status.status) return false;
+  if (page.properties.Description.type !== 'rich_text') return false;
+  if (page.properties['Cover URL'].type !== 'rich_text') return false;
+  if (page.properties['Home Cover URL'].type !== 'rich_text') return false;
+  if (page.properties.Slug.type !== 'rich_text') return false;
+
   let date = '';
-  if (page.properties.Date.date.start.includes('T')) {
-    date = format(parseISO(page.properties.Date.date.start), 'MMMM dd, yyyy h:mm a');
+  if (!page.properties.Date.date) {
+    date = 'January 1, 2000';
   } else {
-    date = format(parseISO(page.properties.Date.date.start), 'MMMM dd, yyyy');
+    if (page.properties.Date.date.start.includes('T')) {
+      date = format(parseISO(page.properties.Date.date.start), 'MMMM dd, yyyy h:mm a');
+    } else {
+      date = format(parseISO(page.properties.Date.date.start), 'MMMM dd, yyyy');
+    }
   }
 
   return {
-    eventName: page.properties.Name.title[0].text.content,
+    eventName: page.properties.Name.title[0]?.plain_text || 'Event',
     date,
-    venue: page.properties.Venue.rich_text[0].plain_text,
+    venue: page.properties.Venue.rich_text[0]?.plain_text || 'Carleton University',
     status: page.properties.Status.status.name,
-    description: page.properties.Description.rich_text[0]?.plain_text || '',
+    description: page.properties.Description.rich_text[0]?.plain_text || 'Description',
     coverURL: page.properties['Cover URL'].rich_text[0]?.plain_text || '/default',
     homePageImageURL: page.properties['Home Cover URL'].rich_text[0]?.plain_text || '/default',
     slug: page.properties.Slug.rich_text[0]?.plain_text || pageId,

--- a/src/lib/notion/external.ts
+++ b/src/lib/notion/external.ts
@@ -1,3 +1,4 @@
+import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import notion from '.';
 import { getPageIds } from './utils';
 
@@ -13,9 +14,9 @@ export async function getExternalPageSlugs(): Promise<string[]> {
   });
 
   const results = res.results.map(result => {
-    const typedResult = result as any;
+    const typedResult = result as PageObjectResponse;
+    if (typedResult.properties.Slug.type !== 'url' || !typedResult.properties.Slug.url) return '';
     const slug = typedResult.properties.Slug.url;
-    // const slug = encodeURI(title);
     return slug;
   });
 

--- a/src/lib/notion/projects.ts
+++ b/src/lib/notion/projects.ts
@@ -57,7 +57,15 @@ export async function getProjects(options?: { featuredOnly: boolean }) {
 }
 
 export async function getProjectPageBySlug(slug: string) {
-  return getPageBySlug(PROJECTS_DATABASE_ID, slug);
+  const projectPage = await getPageBySlug(PROJECTS_DATABASE_ID, slug);
+  if (!projectPage) return undefined;
+  if (!isFullPage(projectPage)) return undefined;
+
+  const projectPageId = projectPage.id;
+  const properties = getProjectPageProperties(projectPage, projectPageId);
+  if (!properties) return undefined;
+
+  return { projectPageId, ...properties };
 }
 
 function getProjectPageProperties(page: PageObjectResponse, pageId: string) {

--- a/src/lib/notion/projects.ts
+++ b/src/lib/notion/projects.ts
@@ -1,5 +1,7 @@
+import { isFullPage } from '@notionhq/client';
 import notion from '.';
 import { getPageBySlug, getPageIds } from './utils';
+import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 
 export type ProjectDataType = {
   pageId: string;
@@ -10,7 +12,7 @@ export type ProjectDataType = {
   year: string | undefined | null;
   logoUrl: string | undefined | null;
   externalUrl: string | undefined | null;
-  status: 'Not started' | 'Done' | 'In progress' | undefined | null;
+  status: 'Not started' | 'Done' | 'In progress' | string | undefined | null;
   gitHubUrl: string | undefined | '';
 };
 
@@ -35,36 +37,20 @@ export async function getProjects(options?: { featuredOnly: boolean }) {
   const projects: ProjectDataType[] = [];
 
   for (const pageId of projectPageIds) {
-    const page = (await notion.pages.retrieve({ page_id: pageId })) as any;
+    const page = await notion.pages.retrieve({ page_id: pageId });
 
-    const isFeatured = page.properties.Featured.checkbox;
+    if (!isFullPage(page)) continue;
+    if (page.properties.Featured.type !== 'checkbox') continue;
+    if (page.properties.Visibility.type !== 'checkbox') continue;
 
-    if (featuredOnly && !isFeatured) {
+    if ((featuredOnly && !page.properties.Featured.checkbox) || !page.properties.Visibility.checkbox) {
       continue;
     }
 
-    const companyName = page.properties.Name.title[0].plain_text;
-    const productName = page.properties['Product Name'].rich_text[0]?.plain_text;
-    const description = page.properties.Description.rich_text[0]?.plain_text;
-    const year = page.properties.Year.rich_text[0]?.plain_text;
-    const logoUrl = page.properties['Logo URL'].rich_text[0]?.plain_text || '/default';
-    const externalUrl = page.properties.URL.url;
-    const status = page.properties.Status.select.name;
-    const gitHubUrl = page.properties.gitHubUrl.url;
-    const slug = page.properties.Slug.rich_text[0]?.plain_text || pageId;
+    const properties = getProjectPageProperties(page, pageId);
+    if (!properties) continue;
 
-    projects.push({
-      pageId,
-      companyName,
-      productName,
-      description,
-      year,
-      logoUrl,
-      externalUrl,
-      status,
-      gitHubUrl,
-      slug,
-    });
+    projects.push({ pageId, ...properties });
   }
 
   return projects;
@@ -72,4 +58,28 @@ export async function getProjects(options?: { featuredOnly: boolean }) {
 
 export async function getProjectPageBySlug(slug: string) {
   return getPageBySlug(PROJECTS_DATABASE_ID, slug);
+}
+
+function getProjectPageProperties(page: PageObjectResponse, pageId: string) {
+  if (page.properties.Name.type !== 'title') return false;
+  if (page.properties['Product Name'].type !== 'rich_text') return false;
+  if (page.properties.Description.type !== 'rich_text') return false;
+  if (page.properties.Year.type !== 'rich_text') return false;
+  if (page.properties['Logo URL'].type !== 'rich_text') return false;
+  if (page.properties.URL.type !== 'url') return false;
+  if (page.properties.Status.type !== 'status' || !page.properties.Status.status) return false;
+  if (page.properties.gitHubUrl.type !== 'url') return false;
+  if (page.properties.Slug.type !== 'rich_text') return false;
+
+  return {
+    companyName: page.properties.Name.title[0]?.plain_text || 'Company Name',
+    productName: page.properties['Product Name'].rich_text[0]?.plain_text,
+    description: page.properties.Description.rich_text[0]?.plain_text,
+    year: page.properties.Year.rich_text[0]?.plain_text,
+    logoUrl: page.properties['Logo URL'].rich_text[0]?.plain_text || '/default',
+    externalUrl: page.properties.URL.url,
+    status: page.properties.Status.status.name,
+    gitHubUrl: page.properties.gitHubUrl.url || '',
+    slug: page.properties.Slug.rich_text[0]?.plain_text || pageId,
+  };
 }

--- a/src/lib/notion/students.ts
+++ b/src/lib/notion/students.ts
@@ -1,3 +1,4 @@
+import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import notion from '.';
 import { cache } from 'react';
 
@@ -28,10 +29,21 @@ export const getStudents = cache(async () => {
 
   const studentsArray: StudentDataType[] = [];
 
-  for (const student of res.results as any) {
-    const name = student.properties.Name.title[0].plain_text;
-    const team = student.properties.Team.select.name;
-    const role = student.properties.Roles.select.name;
+  for (const student of res.results as PageObjectResponse[]) {
+    if (student.properties.Visibility.type !== 'checkbox') continue;
+    if (!student.properties.Visibility.checkbox) {
+      continue;
+    }
+
+    if (student.properties.Name.type !== 'title') continue;
+    if (student.properties.Team.type !== 'select') continue;
+    if (student.properties.Roles.type !== 'select') continue;
+    if (student.properties.Photo.type !== 'rich_text') continue;
+    if (student.properties.Link.type !== 'url') continue;
+
+    const name = student.properties.Name.title[0]?.plain_text || 'Name';
+    const team = student.properties.Team.select?.name || 'Executive';
+    const role = student.properties.Roles.select?.name || 'Role';
     const imageUrl = student.properties.Photo.rich_text[0]?.plain_text || '/default';
     const personalUrl = student.properties.Link.url !== null ? student.properties.Link.url : 'No URL';
     studentsArray.push({ name, team, role, imageUrl, personalUrl });

--- a/src/lib/notion/utils.ts
+++ b/src/lib/notion/utils.ts
@@ -41,7 +41,7 @@ export async function getTitleByPageId(page_id: string) {
   const res = await notion.pages.retrieve({ page_id });
   const typedRes = res as PageObjectResponse;
   if (typedRes.properties.Name.type !== 'title') return 'Untitled';
-  return typedRes.properties.Name.title[0].plain_text;
+  return typedRes.properties.Name.title[0].plain_text || 'Untitled';
 }
 
 export async function getPageBySlug(database_id: string, slug: string) {

--- a/src/lib/notion/utils.ts
+++ b/src/lib/notion/utils.ts
@@ -4,6 +4,7 @@ import notion from '.';
 import { getEventPageIds } from './events';
 import { getProjectPageIds } from './projects';
 import { getAnnouncementsPageIds } from './announcements';
+import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 
 /*
  * `notion-client` is the unofficial notion API library (not the same as – @notionhq/client)
@@ -38,7 +39,8 @@ export async function getPageIds(database_id: string): Promise<string[]> {
 
 export async function getTitleByPageId(page_id: string) {
   const res = await notion.pages.retrieve({ page_id });
-  const typedRes = res as any;
+  const typedRes = res as PageObjectResponse;
+  if (typedRes.properties.Name.type !== 'title') return 'Untitled';
   return typedRes.properties.Name.title[0].plain_text;
 }
 
@@ -55,5 +57,5 @@ export async function getPageBySlug(database_id: string, slug: string) {
 
   if (!res.results.length) return undefined;
 
-  return res.results[0];
+  return res.results[0] as PageObjectResponse;
 }


### PR DESCRIPTION
# Description of Changes
- Replaced uses of "any" with PageObjectResponse type
- Added type guards before accessing page properties
- Added default values for all page properties
- Implemented visibility control and added visibility checkbox for all databases on Notion

## Related Issues

- Closes #195 

## Checklist

- [x] MR title is meaningful and accurate
- [x] This MR has an associated GitHub Issues ticket
- [x] Code quality check has been run `npm run quality`
- [x] Preview deployment has passed and looks as expected
- [x] I promise that my commit message for this MR will be clear, meaningful,
      and useful to others. I will ensure this by editing the final commit message
      in GitHub prior to merging

If a checklist item is completed for this MR, place an `x` inside of the square
brackets for that item. If a checklist item is not applicable for this MR, please
note that by wrapping that line with `~` characters, ~like this~.

> Make sure you squash your commits before merging!
