### PR TITLE
Fixed HeroBlock image alignment

### DIFF
--- a/src/app/(pages)/home/_components/HeroBlock.tsx
+++ b/src/app/(pages)/home/_components/HeroBlock.tsx
@@ -35,7 +35,7 @@ export default async function HeroBlock() {
           <Image src={mobileHome} className="bottom-0 right-0 block w-full md:hidden" alt="Home" />
         </div>
       </div>
-      <Image src={home} className="absolute -right-24 top-0 hidden md:block md:w-1/2" alt="Home" />
+      <Image src={home} className="absolute left-[55%] top-0 hidden h-full w-auto md:block" alt="Home" />
     </div>
   );
 }


### PR DESCRIPTION
# Description of Changes

- Set the height of the image to take up the full size of the HeroBlock
- Aligned the image 55% from the left so the image always starts a bit more than half way across the block

## Related Issues

- Closes #218 

## Checklist

- [x] MR title is meaningful and accurate
- [x] This MR has an associated GitHub Issues ticket
- [x] Code quality check has been run `npm run quality`
- [x] Preview deployment has passed and looks as expected
- [x] I promise that my commit message for this MR will be clear, meaningful,
      and useful to others. I will ensure this by editing the final commit message
      in GitHub prior to merging

If a checklist item is completed for this MR, place an `x` inside of the square
brackets for that item. If a checklist item is not applicable for this MR, please
note that by wrapping that line with `~` characters, ~like this~.

> Make sure you squash your commits before merging!
