### PR TITLE
Site wide ODR route in favour of routed ODR for hourly revalidation

### DIFF
--- a/.github/workflows/hourly-revalidation.yml
+++ b/.github/workflows/hourly-revalidation.yml
@@ -8,11 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger on demand revalidation for home page
+      - name: Trigger on demand revalidation site wide
         run: curl -X POST -d '{}' "carletonblueprint.org/api/revalidate/home"
-      - name: Trigger on demand revalidation for projects page
-        run: curl -X POST -d '{}' "carletonblueprint.org/api/revalidate/projects"
-      - name: Trigger on demand revalidation for events page
-        run: curl -X POST -d '{}' "carletonblueprint.org/api/revalidate/events"
-      - name: Trigger on demand revalidation for students page
-        run: curl -X POST -d '{}' "carletonblueprint.org/api/revalidate/students"
+      - name: Visit the site
+        run: curl -X GET "https://carletonblueprint.org"

--- a/.github/workflows/hourly-revalidation.yml
+++ b/.github/workflows/hourly-revalidation.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger on demand revalidation site wide
-        run: curl -X POST -d '{}' "carletonblueprint.org/api/revalidate/home"
+        run: curl -X POST -d '{}' "carletonblueprint.org/api/revalidate"
       - name: Visit the site
         run: curl -X GET "https://carletonblueprint.org"

--- a/.github/workflows/hourly-revalidation.yml
+++ b/.github/workflows/hourly-revalidation.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger on demand revalidation site wide
-        run: curl -X POST -d '{}' "carletonblueprint.org/api/revalidate"
+        run: curl -X POST -d '{}' "https://carletonblueprint.org/api/revalidate"
       - name: Visit the site
         run: curl -X GET "https://carletonblueprint.org"

--- a/src/app/api/revalidate/events/route.ts
+++ b/src/app/api/revalidate/events/route.ts
@@ -1,8 +1,0 @@
-'use server';
-import { NextResponse } from 'next/server';
-import { revalidatePath } from 'next/cache';
-
-export async function POST() {
-  revalidatePath('/events');
-  return NextResponse.json({ message: 'Hit endpoint', status: 200 });
-}

--- a/src/app/api/revalidate/home/route.ts
+++ b/src/app/api/revalidate/home/route.ts
@@ -1,9 +1,0 @@
-'use server';
-import { NextResponse } from 'next/server';
-import { revalidatePath } from 'next/cache';
-
-export async function POST() {
-  revalidatePath('/');
-  revalidatePath('/home');
-  return NextResponse.json({ message: 'Successfully revalidated / and /home', status: 200 });
-}

--- a/src/app/api/revalidate/projects/route.ts
+++ b/src/app/api/revalidate/projects/route.ts
@@ -1,8 +1,0 @@
-'use server';
-import { NextResponse } from 'next/server';
-import { revalidatePath } from 'next/cache';
-
-export async function POST() {
-  revalidatePath('/projects');
-  return NextResponse.json({ message: 'Successfully revalidated /projects', status: 200 });
-}

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -3,6 +3,6 @@ import { NextResponse } from 'next/server';
 import { revalidatePath } from 'next/cache';
 
 export async function POST() {
-  revalidatePath('/students');
-  return NextResponse.json({ message: 'Successfully revalidated /', status: 200 });
+  revalidatePath('/', 'layout');
+  return NextResponse.json({ message: 'Successfully revalidated site', status: 200 });
 }


### PR DESCRIPTION
# Description of Changes

- Removed all revalidation routes, replacing them with one main revalidate route (carletonblueprint.org/api/revalidate)
- On demand revalidation (ODR) will now revalidate the whole site with one trigger
- Updated hourly-revalidation GitHub action to use new ODR route and also visit the site after revalidation (to trigger the fetch)

## Related Issues

- ~~Closes [ISSUE NUMBER HERE]~~

## Checklist

- [x] MR title is meaningful and accurate
- [ ] This MR has an associated GitHub Issues ticket
- [x] Code quality check has been run `npm run quality`
- [x] Preview deployment has passed and looks as expected
- [x] I promise that my commit message for this MR will be clear, meaningful,
      and useful to others. I will ensure this by editing the final commit message
      in GitHub prior to merging

If a checklist item is completed for this MR, place an `x` inside of the square
brackets for that item. If a checklist item is not applicable for this MR, please
note that by wrapping that line with `~` characters, ~like this~.

> Make sure you squash your commits before merging!
